### PR TITLE
text changes.

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -645,7 +645,7 @@
 
                                         <br>
                                         <br>
-                                        They are attached to the fall using a cow hitch that has been passed through the center of the fall using a micro lacing needle. These can be undone without any special equipment; however, if you aim to replace the cracker and don’t have a lacing needle you will have difficulties. Contact us for recommended methods of replacing the cracker or view our recommended videos.
+                                        They are attached to the fall using a cow hitch that has been passed through the center of the fall using a micro lacing needle. These can be undone without any special equipment; however, if you aim to replace the cracker and don’t have a lacing needle you will have difficulties. Contact us for recommended methods of replacing the cracker or check out WhipWorks' video titled "How to replace your Bullwhip's Crack, properly!" on YouTube.
                                     </p>
                                     <ul class="list-inline">
                                         <!-- <li>Date: January 2020</li>
@@ -1204,14 +1204,14 @@
 
                                 <br><br><br><br><br>
 
-                                <p class="item-intro text-muted">3 color striped 6 foot bullwhip</p>
+                                <p class="item-intro text-muted">3 color striped 8 foot bullwhip</p>
                                 <img class="img-fluid d-block mx-auto" src="assets/img/order/in-stock/white-purple-black.JPG" alt="" />
                                 <p> 3 color striped 6 foot bullwhip with 8" handle, waxed. The nylon cracker will be switched to kevlar before shipping.
                                 </p>
                                 <ul class="list-inline">
-                                    <li>Price: $175</li>
+                                    <li>Price: $250</li>
                                     <li>Made: August 2020</li>
-                                    <li>Length: 6 foot</li>
+                                    <li>Length: 8 foot</li>
                                     <li>Handle: 8 inches</li>
                                 </ul>
 


### PR DESCRIPTION
An 8' whip was labled as 6' and priced wrong.

Removed language refrencing a recomended videos section.